### PR TITLE
Fix: Footer mount event

### DIFF
--- a/src/js/components/footer/Footer.ts
+++ b/src/js/components/footer/Footer.ts
@@ -72,11 +72,8 @@ const buildComponent = (): HTMLDivElement => {
 };
 
 const render = (): void => {
-    document.addEventListener("DOMContentLoaded", () => {
-        document.body.appendChild(buildComponent());
-    });
-    //const root: HTMLDivElement = document.querySelector(".root")!;
-    //root.after(buildComponent());
+    const root: HTMLDivElement = document.querySelector(".root")!;
+    root.after(buildComponent());
 };
 
 render();


### PR DESCRIPTION
- Use after() method on root container instead of using an event listener to delay footer mount